### PR TITLE
Fix: Restore namespaced tag support (e.g. <svg:g>) in end tag regex a…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lastboy/vue2",
-  "version": "6.4.3",
+  "version": "6.4.4",
   "packageManager": "pnpm@8.9.2",
   "description": "Fork of Vue 2.7.16 with patched CVE-2024-9506 (regex ReDoS vulnerability)",
   "main": "dist/vue.runtime.common.js",

--- a/src/compiler/parser/html-parser.ts
+++ b/src/compiler/parser/html-parser.ts
@@ -23,7 +23,8 @@ const ncname = `[a-zA-Z_][\\-\\.0-9_a-zA-Z${unicodeRegExp.source}]*`
 const qnameCapture = `((?:${ncname}\\:)?${ncname})`
 const startTagOpen = new RegExp(`^<${qnameCapture}`)
 const startTagClose = /^\s*(\/?)>/
-const endTag = /^<\/([a-zA-Z_][\w\-\.]*)[^>]*>/;
+const endTag = /^<\/((?:[a-zA-Z_][\w\-\.]*:)?[a-zA-Z_][\w\-\.]*)[^>]*>/;
+
 const doctype = /^<!DOCTYPE [^>]+>/i
 // #7298: escape - to avoid being passed as HTML comment when inlined in page
 const comment = /^<!\--/

--- a/test/patch-test/main.test.js
+++ b/test/patch-test/main.test.js
@@ -1,10 +1,13 @@
 function runTest() {
+
   if (!window.Vue) {
-    console.error('❌ Vue is not available.')
+    const red = '\x1b[31m', reset = '\x1b[0m'
+    console.error(`${red}Vue is not available.${reset}`)
     return
   }
 
-  console.log('Vue version:', Vue.version)
+  const cyan = '\x1b[36m', reset = '\x1b[0m';
+  console.log(`[test patch] ${cyan}Vue version:${reset}`, Vue.version)
 
   const payload = `
     <div>
@@ -22,7 +25,6 @@ function runTest() {
     },
     msg => {
       if (!capturedMessage) {
-        
         capturedMessage = msg.slice(0, 50) + '...'
       }
     }
@@ -30,22 +32,20 @@ function runTest() {
 
   const duration = performance.now() - start
 
+  const yellow = '\x1b[33m'
   if (capturedMessage) {
-    const yellow = '\x1b[33m'
-    const reset = '\x1b[0m'
-    console.warn(`${yellow}[⚠️ Compile Warning]${reset} ${capturedMessage}`)
+    console.warn(`${yellow}[Compile Warning]\x1b[0m ${capturedMessage}`)
   }
 
-  console.log('⏱ Time:', duration.toFixed(2), 'ms')
+  console.log(`${cyan} Time:${reset}`, duration.toFixed(2), 'ms')
 
   const red = '\x1b[31m'
   const green = '\x1b[32m'
-  const reset = '\x1b[0m'
 
   console.log(
     duration > 1000
       ? `${red}❗ VULNERABLE — CVE-2024-9506 triggered${reset}`
-      : `${green}✅ Not vulnerable (fast parse)${reset}`
+      : `${green} Not vulnerable (fast parse)${reset}`
   )
 }
 
@@ -54,10 +54,18 @@ function suppressAndCapture(fn, onMsg) {
   const originalError = console.error
 
   console.warn = (msg, ...args) => {
+    const red = '\x1b[31m', reset = '\x1b[0m'
+    if (typeof msg === 'string' && msg.includes('Error compiling template')) {
+      msg = `${red}${msg}${reset}`
+    }
     if (typeof onMsg === 'function') onMsg(msg)
   }
 
   console.error = (msg, ...args) => {
+    const red = '\x1b[31m', reset = '\x1b[0m'
+    if (typeof msg === 'string' && msg.includes('Error compiling template')) {
+      msg = `${red}${msg}${reset}`
+    }
     if (typeof onMsg === 'function') onMsg(msg)
   }
 
@@ -68,6 +76,7 @@ function suppressAndCapture(fn, onMsg) {
     console.error = originalError
   }
 }
+
 
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', runTest)

--- a/test/patch-test/not-patched.html
+++ b/test/patch-test/not-patched.html
@@ -3,7 +3,7 @@
 
 <head>
   <title>Vue CDN Test</title>
-  <script src="https://cdn.jsdelivr.net/npm/vue@2.7.16/dist/vue.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vue@2.7.16"></script>
   <script src="main.test.js"></script>
 </head>
 

--- a/test/patch-test/patched-namespace.html
+++ b/test/patch-test/patched-namespace.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Vue CDN Test</title>
+    <script src="../../dist/vue.js"></script>
+    <!-- or wherever your local bundle is -->
+    <script src="main.test.js"></script>
+  </head>
+
+  <body>
+    <script>
+      document.body.innerHTML = `
+      <div id="test1"></div>
+      <div id="test2"></div>
+    `
+
+      // No namespace — should always work
+      // Console color helpers
+      const cyan = '\x1b[36m',
+        reset = '\x1b[0m'
+
+      // No namespace — should always work
+      console.log('\n');
+      console.log(`${cyan}Running [test with-no-namespace]: basic custom tag test...${reset}`)
+      new Vue({
+        el: '#test1',
+        components: {
+          'custom-tag': {
+            template: '<span>ok</span>'
+          }
+        },
+        template: '<div><custom-tag /></div>',
+        mounted() {
+          const html = this.$el.innerHTML
+          console.log('[test with-no-namespace] rendered:', html)
+          if (html.includes('<span>ok</span>')) {
+            console.log('[test with-no-namespace] ✅ Passed')
+          } else {
+            console.error('[test with-no-namespace] ❌ Failed')
+          }
+        }
+      })
+
+      // Namespaced element — fails in buggy version, works with patch
+      console.log('\n');
+      console.log(
+        `\n${cyan}Running [test with-namespace]: namespaced tag <svg:g> test...${reset}`
+      )
+      new Vue({
+        el: '#test2',
+        template: '<svg><svg:g>svg content</svg:g></svg>',
+        mounted() {
+          const g = this.$el.querySelector('g')
+          if (g && g.innerHTML.includes('svg content')) {
+            console.log('[test with-namespace] ✅ Passed (namespace supported)')
+          } else {
+            console.error('[test with-namespace] ❌ Failed (namespace not handled)')
+          }
+        }
+      })
+    </script>
+  </body>
+</html>

--- a/test/patch-test/patched.html
+++ b/test/patch-test/patched.html
@@ -3,7 +3,7 @@
 
 <head>
   <title>Vue CDN Test</title>
-  <script src="../../dist/vue.js"></script> <!-- or wherever your local bundle is -->
+  <script src="../../dist/vue.js"></script>
   <script src="main.test.js"></script>
 </head>
 

--- a/test/patch-test/test-runner.js
+++ b/test/patch-test/test-runner.js
@@ -2,6 +2,7 @@ const puppeteer = require('puppeteer')
 const path = require('path')
 
 async function runTest(file) {
+    console.log(`\n -------------> Loading test file: ${file}\n`);
   const browser = await puppeteer.launch({
     args: ['--allow-file-access-from-files']
   })
@@ -17,6 +18,7 @@ async function runTest(file) {
 }
 
 ;(async () => {
+  await runTest('patched-namespace.html')
   await runTest('not-patched.html')
   await runTest('patched.html')
 })()


### PR DESCRIPTION
Restores support for namespace tags (e.g., <svg:g>) in the Vue2 template compiler's endTag regex, while preserving the fix for [CVE-2024-9506](https://nvd.nist.gov/vuln/detail/CVE-2024-9506)

---
## Test

A dedicated test was added to verify this behavior:

✅ e.g. <svg:g> tags now compile and render successfully
✅ Custom tag behavior remains intact
✅ The ReDoS vector still results in fast parsing with no performance issue

The test files include:

patched-namespace.html: specifically tests namespaced tag handling
not-patched.html: confirms the original unpatched version is still vulnerable (against the original 2.7.16 bundle)
patched.html: verifies patch works and compiles correctly 
